### PR TITLE
Add configurable max items and max title length

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ func main() {
 
 	flag.StringVar(&dbpath, "dbpath", "todo.db", "Database path")
 	flag.StringVar(&bind, "bind", "0.0.0.0:8000", "[int]:<port> to bind to")
-	flag.IntVar(&MAX_ITEMS, "MAX_ITEMS", 100, "maximum number of items allowed in the todo list")
-	flag.IntVar(&MAX_TITLE_LENGTH, "MAX_TITLE_LENGTH", 100, "maximum valid length of a todo item's title")
+	flag.IntVar(&maxItems, "max-items", 100, "maximum number of items allowed in the todo list")
+	flag.IntVar(&maxTitleLength, "max-title-length", 100, "maximum valid length of a todo item's title")
 	flag.Parse()
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ func main() {
 	var (
 		dbpath           string
 		bind             string
-		MAX_ITEMS        int
-		MAX_TITLE_LENGTH int
+		maxItems        int
+		maxTitleLength int
 	)
 
 	flag.StringVar(&dbpath, "dbpath", "todo.db", "Database path")

--- a/main.go
+++ b/main.go
@@ -32,5 +32,5 @@ func main() {
 	}
 	defer db.Close()
 
-	newServer(bind, MAX_ITEMS, MAX_TITLE_LENGTH).listenAndServe()
+	newServer(bind, maxItems, maxTitleLength).listenAndServe()
 }

--- a/main.go
+++ b/main.go
@@ -13,16 +13,16 @@ var (
 
 func main() {
 	var (
-		dbpath           string
-		bind             string
-		maxItems        int
+		dbpath         string
+		bind           string
+		maxItems       int
 		maxTitleLength int
 	)
 
 	flag.StringVar(&dbpath, "dbpath", "todo.db", "Database path")
 	flag.StringVar(&bind, "bind", "0.0.0.0:8000", "[int]:<port> to bind to")
-	flag.IntVar(&maxItems, "max-items", 100, "maximum number of items allowed in the todo list")
-	flag.IntVar(&maxTitleLength, "max-title-length", 100, "maximum valid length of a todo item's title")
+	flag.IntVar(&maxItems, "maxitems", 100, "maximum number of items allowed in the todo list")
+	flag.IntVar(&maxTitleLength, "maxtitlelength", 100, "maximum valid length of a todo item's title")
 	flag.Parse()
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -13,12 +13,16 @@ var (
 
 func main() {
 	var (
-		dbpath string
-		bind   string
+		dbpath           string
+		bind             string
+		MAX_ITEMS        int
+		MAX_TITLE_LENGTH int
 	)
 
 	flag.StringVar(&dbpath, "dbpath", "todo.db", "Database path")
 	flag.StringVar(&bind, "bind", "0.0.0.0:8000", "[int]:<port> to bind to")
+	flag.IntVar(&MAX_ITEMS, "MAX_ITEMS", 100, "maximum number of items allowed in the todo list")
+	flag.IntVar(&MAX_TITLE_LENGTH, "MAX_TITLE_LENGTH", 100, "maximum valid length of a todo item's title")
 	flag.Parse()
 
 	var err error
@@ -28,5 +32,5 @@ func main() {
 	}
 	defer db.Close()
 
-	newServer(bind).listenAndServe()
+	newServer(bind, MAX_ITEMS, MAX_TITLE_LENGTH).listenAndServe()
 }

--- a/models.go
+++ b/models.go
@@ -4,14 +4,7 @@ import (
 	"time"
 )
 
-const (
-	// maxTitleLength is the maximum valid length of a todo item's title.
-	// Todo items that exceed this length are stripped. This is to prevent
-	// abuse primarily.
-	maxTitleLength = 100
-)
-
-// Todo ...
+// Todo represents a single item on the todo list
 type Todo struct {
 	ID        uint64
 	Done      bool
@@ -21,10 +14,6 @@ type Todo struct {
 }
 
 func newTodo(title string) *Todo {
-	if len(title) > maxTitleLength {
-		title = title[:maxTitleLength]
-	}
-
 	return &Todo{
 		Title:     title,
 		CreatedAt: time.Now(),
@@ -42,7 +31,7 @@ func (t *Todo) toggleDone() {
 	t.UpdatedAt = time.Now()
 }
 
-// TodoList ...
+// TodoList represents a slice of todo items
 type TodoList []*Todo
 
 func (a TodoList) Len() int           { return len(a) }


### PR DESCRIPTION
These values are grabbed from the `MAX_ITEMS and MAX_TITLE_LENGTH` environment variables. If there is a problem parsing these environment variables, an error is returned and the default values are used, which is 100 for both values.