### PR TITLE
Docker Images changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
 FROM golang:alpine AS builder
-
+# Install Dependencies
 RUN \
     apk add --update git && \
     rm -rf /var/cache/apk/*
-
+# Add user
 RUN addgroup -S gouser && adduser -S gouser -G gouser 
-
+# Prepare folders and install main app
 RUN mkdir -p /usr/local/go/src/todo
-RUN mkdir -p /data
 WORKDIR /usr/local/go/src/todo
-
 COPY . /usr/local/go/src/todo
-
 RUN go get -v -d
 RUN go install -v
 RUN go build .
-
+# ---------
 FROM alpine:latest
 # Copy CA certificates to be able to connect to HTTPS sites.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
  # COPY /etc/passwd and /etc/group to have the user in new image
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+# Copy app files
 ENV GOPATH=/usr/local/go
 COPY --from=builder --chown=gouser:gouser /usr/local/go/src/todo/ /usr/local/go/src/todo
 WORKDIR /usr/local/go/src/todo
@@ -29,5 +27,4 @@ WORKDIR /usr/local/go/src/todo
 USER gouser:gouser
 
 EXPOSE 8000/tcp
-
 ENTRYPOINT ["/usr/local/go/src/todo/todo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,3 @@ USER gouser:gouser
 EXPOSE 8000/tcp
 
 ENTRYPOINT ["/usr/local/go/src/todo/todo"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,34 @@
-FROM golang:alpine
-
-EXPOSE 8000/tcp
-
-ENTRYPOINT ["todo"]
+FROM golang:alpine AS builder
 
 RUN \
     apk add --update git && \
     rm -rf /var/cache/apk/*
 
+RUN addgroup -S gouser && adduser -S gouser -G gouser 
+
 RUN mkdir -p /usr/local/go/src/todo
+RUN mkdir -p /data
 WORKDIR /usr/local/go/src/todo
 
 COPY . /usr/local/go/src/todo
 
 RUN go get -v -d
-RUN go get github.com/GeertJohan/go.rice/rice
 RUN go install -v
-RUN rice embed-go
 RUN go build .
+
+FROM alpine:latest
+# Copy CA certificates to be able to connect to HTTPS sites.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+ # COPY /etc/passwd and /etc/group to have the user in new image
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+ENV GOPATH=/usr/local/go
+COPY --from=builder --chown=gouser:gouser /usr/local/go/src/todo/ /usr/local/go/src/todo
+WORKDIR /usr/local/go/src/todo
+# Drop privileges, don't run as root
+USER gouser:gouser
+
+EXPOSE 8000/tcp
+
+ENTRYPOINT ["/usr/local/go/src/todo/todo"]
+


### PR DESCRIPTION
Using staged builds the image size can be drastically reduced. 

```
sudneo/todo                        latest              476caa8a8bb5        6 minutes ago       17.2MB
prologic/todo                      latest              255c1c5439ae        5 months ago        450MB
```

The only thing that I didn't manage to get working is the rice embed files. If the source build used rice embed, I will forever get 404 on the color-theme.css file. 

It seemed that the server couldn't find the css from the disk, as this changes at runtime. I had never used this library before, so it might simply require more time, for my use case, definitely it is not an issue.

Also, I used a dedicated user to run the app, as running as root might pose a security threat, especially since people might mount random directories to save the db.

